### PR TITLE
Issue 11 be compatible with rails view annotation comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    validate_html (0.1.0)
+    validate_html (0.2.0)
       nokogiri
 
 GEM
@@ -65,6 +65,7 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
     minitest (5.17.0)
     net-imap (0.3.1)
       net-protocol
@@ -74,9 +75,8 @@ GEM
       timeout
     net-smtp (0.3.2)
       net-protocol
-    nokogiri (1.13.10-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -165,6 +165,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/validate_html/version.rb
+++ b/lib/validate_html/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ValidateHTML
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/validate_html/rack_middleware_spec.rb
+++ b/spec/validate_html/rack_middleware_spec.rb
@@ -37,6 +37,23 @@ RSpec.describe ValidateHTML::RackMiddleware do
       end
     end
 
+    context 'with config.action_view.annotate_rendered_view_with_filenames=true HTML' do
+      let(:body_with_leading_comment_removed) { '<!DOCTYPE html><html><body><p>hi</p></body></html>' }
+      let(:body) { "<!-- BEGIN app/views/layouts/site.html.erb -->#{body_with_leading_comment_removed}" }
+
+      it 'does not raise an error' do
+        expect(middleware.call(env)).to eq [200, headers, body]
+      end
+
+      it 'calls ValidateHTML.validate_html with the leading comment removed' do
+        allow(ValidateHTML).to receive(:validate_html)
+
+        middleware.call(env)
+
+        expect(ValidateHTML).to have_received(:validate_html).with(body_with_leading_comment_removed, anything)
+      end
+    end
+
     context 'with invalid html in an array for some reason' do
       let(:body) { ['<strong><em>Emphasis</strong></em>'] }
 

--- a/spec/validate_html_spec.rb
+++ b/spec/validate_html_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ValidateHTML do
   let(:valid_html) { '<strong><em>Very Emphasized</em></strong>' }
 
   it 'has a version number' do
-    expect(ValidateHTML::VERSION).to eq '0.1.0'
+    expect(ValidateHTML::VERSION).to eq '0.2.0'
   end
 
   describe '.validate_html' do


### PR DESCRIPTION
If:

    config.action_view.annotate_rendered_view_with_filenames = true

is set in Rails then each rendered view and partial will have a comment
at the top like:

    <!-- BEGIN app/views/thing/index.html.erb -->

When this comment is present before the doctype, it causes the HTML to be
invalid in a way that is not useful so we remove it.

Closes issue #11